### PR TITLE
Added place_sentry_gun

### DIFF
--- a/biglobby_tweak.xml
+++ b/biglobby_tweak.xml
@@ -168,6 +168,21 @@
 				<param type="int" min="1" max="2" />   <!-- spread upgrade level -->
 				<param type="bool" />                  <!-- shield -->
 				<param type="int" min="1" max="2" />   <!-- ammo upgrade level -->
+				<param type="int" min="1" max="2" />   <!-- fire mode index -->
+			</message>
+
+			<message name="biglobby__place_sentry_gun" delivery="ordered" receiver="biglobby__unit" check="client_to_server">
+				<param type="vector3" />
+				<param type="rotation" />
+				<param type="int" min="0" max="32"/> <!-- equipment selection index -->
+				<param type="unit" /> <!-- user_unit -->
+				<param type="int" min="1" max="2" /> <!-- idstring index for sentry type to spawn -->
+				<param type="int" min="1" max="2" />   <!-- ammo upgrade level -->
+				<param type="int" min="1" max="2" />   <!-- fire mode index -->
+			</message>
+
+			<message name="biglobby__picked_up_sentry_gun" delivery="ordered" receiver="biglobby__unit" check="client_to_server">
+				<param type="unit" /> <!-- user_unit -->
 			</message>
 
 			<message name="biglobby__sync_equipment_setup" delivery="ordered" receiver="biglobby__unit" check="server_to_client">

--- a/lua/_custom/biglobby_globals.lua
+++ b/lua/_custom/biglobby_globals.lua
@@ -100,6 +100,8 @@ if not _G.BigLobbyGlobals then
 		'mission_ended',
 		'sync_trip_mine_setup',
 		'from_server_sentry_gun_place_result',
+		'place_sentry_gun',
+		'picked_up_sentry_gun',
 		'sync_equipment_setup',
 		'sync_ammo_bag_setup',
 		'on_sole_criminal_respawned',


### PR DESCRIPTION
Added picked_up_sentry_gun

This is a very untested fix, but there's no more crashing when either host or client is placing, picking up, or changing fire mode now.

There's still several unused functions that may cause issues in the future:
[picked_up_sentry_gun_response](https://github.com/mwSora/payday-2-luajit/blob/master/pd2-lua/lib/network/handlers/unitnetworkhandler.lua#L1675)
[sync_sentrygun_dynamic](https://github.com/mwSora/payday-2-luajit/blob/master/pd2-lua/lib/network/handlers/unitnetworkhandler.lua#L1759)
[sentrygun_ammo](https://github.com/mwSora/payday-2-luajit/blob/master/pd2-lua/lib/network/handlers/unitnetworkhandler.lua#L1767)
[sentrygun_sync_armor_piercing](https://github.com/mwSora/payday-2-luajit/blob/master/pd2-lua/lib/network/handlers/unitnetworkhandler.lua#L1775)
[sync_fire_mode_interaction](https://github.com/mwSora/payday-2-luajit/blob/master/pd2-lua/lib/network/handlers/unitnetworkhandler.lua#L1779)
 
and so on.  Not sure if any of these are needed or not, but will continue to run sentry builds to test.

fixes #32 